### PR TITLE
Correct the "more notifications" URL

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -58,7 +58,7 @@ export default {
 
 	computed: {
 		showMoreUrl() {
-			return this.moodleUrl + '/web/notifications'
+			return this.moodleUrl + '/message/output/popup/notifications.php'
 		},
 		notifications() {
 			return this.upcomingEvents.concat(this.recentItems)


### PR DESCRIPTION
Thanks @pkmkrishnakumar for reporting this and for proposing the correct URL in #4. That URL is the right one in our Moodle, too. Here's a PR with the fix.